### PR TITLE
chore: use exact Python dependencies

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,6 @@
-Flask
-Redis
-gunicorn
-flask-cors
-requests
+Flask==2.1.2
+redis==4.4.4
+gunicorn==20.1.0
+flask-cors==3.0.10
+requests==2.31.0
+urllib3==1.26.15


### PR DESCRIPTION
Use the same versions as in https://github.com/garden-io/garden/blob/main/examples/vote/api/requirements.txt